### PR TITLE
feat: implement agency document access control and application deep linking

### DIFF
--- a/src/app/api/jobApplicationsIUD.tsx
+++ b/src/app/api/jobApplicationsIUD.tsx
@@ -78,3 +78,23 @@ export const deleteJobApplication = async (jobApplicationId: any) => {
     return null;
   }
 };
+
+export const getJobApplicationById = async (jobApplicationId: string) => {
+  try {
+    const { data, error } = await supabase
+      .from("ViewJobApplicationsWithDetails")
+      .select("*")
+      .eq("job_application_id", jobApplicationId)
+      .single();
+
+    if (error) {
+      console.error("Error fetching job application:", error);
+      return null;
+    }
+
+    return data;
+  } catch (error: any) {
+    console.error("Error fetching job application by ID:", error);
+    return null;
+  }
+};

--- a/src/components/agencyComponents/AlumniProfileModal.tsx
+++ b/src/components/agencyComponents/AlumniProfileModal.tsx
@@ -27,6 +27,7 @@ interface AlumniProfileModalProps {
   setOpenAlumniProfile: (isOpen: boolean) => void;
   userType?: string | "alumni";
   setUserType?: (userType: string) => void;
+  viewerType?: string; // Who is viewing the profile (agency, admin, etc.)
 }
 
 interface AlumniData {
@@ -54,6 +55,7 @@ const AlumniProfileModal: React.FC<AlumniProfileModalProps> = ({
   setOpenAlumniProfile,
   userType = "alumni",
   setUserType = () => {},
+  viewerType = "alumni", // Default to alumni if not specified
 }) => {
   const { alumniData } = useAlumni(alumniId, userType);
 
@@ -66,8 +68,11 @@ const AlumniProfileModal: React.FC<AlumniProfileModalProps> = ({
   const [availableDocuments, setAvailableDocuments] = useState<string[]>([]);
   const [employmentStatus, setEmploymentStatus] = useState("");
 
-  // Define all document options (including GTS)
-  const allDocumentOptions = [...documentFiles, "GTS"];
+  // Define all document options based on viewer type (who is viewing)
+  const allDocumentOptions =
+    viewerType === "agency"
+      ? documentFiles // Agency viewers can only see document files (no GTS)
+      : [...documentFiles, "GTS"]; // Alumni and admin viewers can see all documents including GTS
 
   useEffect(() => {
     // Check employment status from GTS
@@ -128,12 +133,17 @@ const AlumniProfileModal: React.FC<AlumniProfileModalProps> = ({
             }
           });
 
-          // Always add GTS as an available option since it's a form
-          setAvailableDocuments([...available, "GTS"]);
+          // Add GTS only if viewerType is not agency
+          if (viewerType !== "agency") {
+            setAvailableDocuments([...available, "GTS"]);
+          } else {
+            // For agency viewers, only show document files
+            setAvailableDocuments(available);
+          }
         }
       }
     }
-  }, [alumniData, alumniId, employmentStatus]);
+  }, [alumniData, alumniId, employmentStatus, userType, viewerType]);
 
   const handleOpenDocument = () => {
     if (!selectedDocumentType) return;
@@ -148,8 +158,8 @@ const AlumniProfileModal: React.FC<AlumniProfileModalProps> = ({
   };
 
   const isDocumentAvailable = (docType: string) => {
-    // GTS is always available
-    if (docType === "GTS") return true;
+    // GTS is only available for non-agency viewers
+    if (docType === "GTS") return viewerType !== "agency";
 
     return availableDocuments.includes(docType);
   };
@@ -345,7 +355,9 @@ const AlumniProfileModal: React.FC<AlumniProfileModalProps> = ({
               <ModalFooter className="flex justify-between items-center gap-2">
                 <div
                   className={`${
-                    userType !== "alumni" && "invisible"
+                    userType !== "alumni" &&
+                    userType !== "agency" &&
+                    "invisible"
                   } flex gap-2 items-center`}
                 >
                   <div className="flex flex-col md:flex-row gap-2 items-center">
@@ -395,7 +407,7 @@ const AlumniProfileModal: React.FC<AlumniProfileModalProps> = ({
         </ModalContent>
       </Modal>
 
-      {userType === "alumni" && (
+      {userType === "alumni" && viewerType !== "agency" && (
         <>
           <GTSComponent
             userInfo={cleanAlumniData}
@@ -418,6 +430,20 @@ const AlumniProfileModal: React.FC<AlumniProfileModalProps> = ({
             employmentStatus={employmentStatus}
           />
         </>
+      )}
+
+      {(userType === "alumni" || userType === "agency") && (
+        <DocumentComponent
+          userID={alumniId}
+          isDocumentModalOpen={isDocumentModalOpen}
+          setIsDocumentModalOpen={setIsDocumentModalOpen}
+          reloadUser={() => {}}
+          documentFile={null}
+          setDocumentFile={() => {}}
+          documentType={selectedDocumentType}
+          isReadOnly={true}
+          employmentStatus={employmentStatus}
+        />
       )}
     </>
   );

--- a/src/components/agencyComponents/Applications.tsx
+++ b/src/components/agencyComponents/Applications.tsx
@@ -24,6 +24,7 @@ import { formatDate } from "@/utils/compUtils";
 import AlumniProfileModal from "./AlumniProfileModal";
 import ApplicationStatusModalComponent from "../ApplicationStatusModal";
 import { programs } from "@/app/api/collegeAndProgramData";
+import { getJobApplicationById } from "@/app/api/jobApplicationsIUD";
 
 const ApplicationsComponent = () => {
   const user = useSelector((state: RootState) => state.user.user);
@@ -48,6 +49,7 @@ const ApplicationsComponent = () => {
   );
   const [searchInput, setSearchInput] = useState("");
   const [programFilter, setProgramFilter] = useState("all");
+  const [viewerUserType, setViewerUserType] = useState("agency");
 
   useEffect(() => {
     if (user) {
@@ -68,31 +70,47 @@ const ApplicationsComponent = () => {
   const totalPages = Math.ceil(totalJobApplications / rowsPerPage);
 
   useEffect(() => {
-    if (!user || loadingJobApplications) return;
+    if (!user) return;
 
     const applicationId = searchParams.get("applicationId");
     const alumniId = searchParams.get("alumniId");
 
-    if (applicationId && jobApplications.length > 0) {
-      const application = jobApplications.find(
-        (app) => app.job_application_id === applicationId
-      );
-      if (application) {
-        setCurrentJobApplicationId(application.job_application_id);
-        setCurrentJobTitle(application.job_title);
-        setCurrentApplicantId(application.applicant_id);
-        setCurrentApplicantEmail(application.applicant_email);
-        setCurrentApplicantFirstName(application.applicant_first_name);
-        setCurrentApplicantLastName(application.applicant_last_name);
-        setCurrentJobPostingId(application.job_posting_id);
-        setIsActionModal(true);
-      }
-    }
-
+    // Handle alumni profile modal
     if (alumniId) {
       setCurrentAlumniId(alumniId);
       setIsAlumniProfileOpen(true);
     }
+
+    // Handle application status modal
+    const handleApplicationModal = async () => {
+      if (applicationId && !loadingJobApplications) {
+        // First try to find in current page
+        let application = jobApplications.find(
+          (app) => app.job_application_id === applicationId
+        );
+
+        // If not found in current page, fetch it directly
+        if (!application) {
+          application = await getJobApplicationById(applicationId);
+        }
+
+        if (application) {
+          setCurrentJobApplicationId(application.job_application_id);
+          setCurrentJobTitle(application.job_title);
+          setCurrentApplicantId(application.applicant_id);
+          setCurrentApplicantEmail(application.applicant_email);
+          setCurrentApplicantFirstName(application.applicant_first_name);
+          setCurrentApplicantLastName(application.applicant_last_name);
+          setCurrentJobPostingId(application.job_posting_id);
+          setIsActionModal(true);
+        } else {
+          // Application not found, clear the URL parameter
+          updateUrlParams({ applicationId: null });
+        }
+      }
+    };
+
+    handleApplicationModal();
   }, [searchParams, user, jobApplications, loadingJobApplications]);
 
   const updateUrlParams = (params: { [key: string]: string | null }) => {
@@ -128,6 +146,8 @@ const ApplicationsComponent = () => {
             updateUrlParams({ alumniId: null });
           }
         }}
+        userType="alumni"
+        viewerType={viewerUserType}
       />
       <ApplicationStatusModalComponent
         isOpen={isActionModal}
@@ -288,6 +308,7 @@ const ApplicationsComponent = () => {
                                   setIsAlumniProfileOpen(true);
                                   updateUrlParams({
                                     alumniId: item.applicant_id,
+                                    applicationId: null, // Clear applicationId to prevent status modal from opening
                                   });
                                 }}
                               >

--- a/src/components/alumniComponents/Dashboard.tsx
+++ b/src/components/alumniComponents/Dashboard.tsx
@@ -526,7 +526,7 @@ const JobPostingDetails = ({
         await insertNotification({
           receiver_id: job.agency_id,
           message: `New application for job posting: ${job.job_title} by ${userName}.`,
-          url: `/agency/applications?applicationId=${response[0].job_application_id}`,
+          url: `/agency/applicants?applicationId=${response[0].job_application_id}`,
         });
 
         const agencySendEmailData = {


### PR DESCRIPTION
- Add document visibility control based on viewer type (agency vs alumni/admin)
  - Agency viewers can only see document files (no GTS access)
  - Alumni and admin viewers retain full document access including GTS
- Implement getJobApplicationById API for direct application fetching
- Enhance application modal handling with direct API fallback
  - Application status modal now fetches applications directly if not found in current page
  - Clear URL parameters when applications are not found
- Update alumni profile modal to conditionally show GTS based on viewer type
- Add viewerType prop to AlumniProfileModal for access control
- Fix application notification URL to point to correct route (/agency/applicants)
- Ensure document component renders appropriately for different user types

BREAKING CHANGE: AlumniProfileModal now requires viewerType prop for proper access control